### PR TITLE
Add remaining operations to main

### DIFF
--- a/src/Trabalho_Programacao_Funcional.py
+++ b/src/Trabalho_Programacao_Funcional.py
@@ -128,19 +128,32 @@ def main():
         opcao = input("Digite o número da operação que deseja realizar: ")
 
         if opcao == '1':
-            numero = float(input("Digite o número: "))
-            expoente = int(input("Digite o expoente (para raízes, digite o índice da raiz): "))
-            operacao = input("Deseja calcular 'potencia' ou 'raiz'? ").lower()
+            try:
+                numero = float(input("Digite o número: "))
+                expoente = int(input("Digite o expoente (para raízes, digite o índice da raiz): "))
+                operacao = input("Deseja calcular 'potencia' ou 'raiz'? ").lower()
 
-            # Função de alta ordem para arredondar o resultado
-            resultado = calcular_potencia_ou_raiz(numero, expoente, operacao, funcao_alta_ordem=lambda x: round(x, 2))
-            print(f"Resultado: {resultado}")
+                # Função de alta ordem para arredondar o resultado
+                resultado = calcular_potencia_ou_raiz(
+                    numero,
+                    expoente,
+                    operacao,
+                    funcao_alta_ordem=lambda x: round(x, 2),
+                )
+                print(f"Resultado: {resultado}")
+            except ValueError:
+                print("Erro: entrada inválida.")
 
         elif opcao == '2':
-            angulo = float(input("Digite o ângulo: "))
-            unidade = input("O ângulo está em 'graus' ou 'radianos'? ").lower()
-            resultados_trig = calcular_trigonometria(angulo, unidade)
-            print(f"Seno: {resultados_trig['seno']}, Cosseno: {resultados_trig['cosseno']}, Tangente: {resultados_trig['tangente']}")
+            try:
+                angulo = float(input("Digite o ângulo: "))
+                unidade = input("O ângulo está em 'graus' ou 'radianos'? ").lower()
+                resultados_trig = calcular_trigonometria(angulo, unidade)
+                print(
+                    f"Seno: {resultados_trig['seno']}, Cosseno: {resultados_trig['cosseno']}, Tangente: {resultados_trig['tangente']}"
+                )
+            except ValueError:
+                print("Erro: entrada inválida.")
 
         elif opcao == '3':
             try:
@@ -192,3 +205,7 @@ def main():
 
         else:
             print("Opção inválida. Tente novamente.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Trabalho_Programacao_Funcional.py
+++ b/src/Trabalho_Programacao_Funcional.py
@@ -143,9 +143,52 @@ def main():
             print(f"Seno: {resultados_trig['seno']}, Cosseno: {resultados_trig['cosseno']}, Tangente: {resultados_trig['tangente']}")
 
         elif opcao == '3':
-            a = float(input("Digite o primeiro número: "))
-            b = float(input("Digite o segundo número: "))
-            operacao = input("Digite a operação ('soma', 'subtracao', 'multiplicacao', 'divisao'): ").lower()
-            resultado, historico = operacoes_basicas(a, b, operacao)
-            print(f"Resultado: {resultado}")
-            print("Histórico de operações")
+            try:
+                a = float(input("Digite o primeiro número: "))
+                b = float(input("Digite o segundo número: "))
+                operacao = input(
+                    "Digite a operação ('soma', 'subtracao', 'multiplicacao', 'divisao'): "
+                ).lower()
+                resultado, historico = operacoes_basicas(a, b, operacao)
+                print(f"Resultado: {resultado}")
+                print("Histórico de operações")
+                for item in historico:
+                    print(item)
+            except ValueError:
+                print("Erro: entrada inválida.")
+
+        elif opcao == '4':
+            try:
+                numero = float(input("Digite o número: "))
+                base_input = input("Digite a base (pressione Enter para base 2): ")
+                base = float(base_input) if base_input else None
+                resultado = calcular_logaritmo(numero, base)
+                print(resultado)
+            except ValueError:
+                print("Erro: entrada inválida.")
+
+        elif opcao == '5':
+            try:
+                a = float(input("Digite o coeficiente a: "))
+                b = float(input("Digite o coeficiente b: "))
+                c = float(input("Digite o coeficiente c: "))
+                resultado = resolver_equacao_segundo_grau(a, b, c)
+                print(resultado)
+            except ValueError:
+                print("Erro: entrada inválida.")
+
+        elif opcao == '6':
+            try:
+                numeros = input("Digite os números separados por espaço: ")
+                lista = [float(x) for x in numeros.split()]
+                resultado = somar_lista_numeros(lista)
+                print(f"Resultado: {resultado}")
+            except ValueError:
+                print("Erro: entrada inválida.")
+
+        elif opcao == '7':
+            print("Saindo...")
+            break
+
+        else:
+            print("Opção inválida. Tente novamente.")


### PR DESCRIPTION
## Summary
- extend the interactive menu in `main()`
- add options for logaritm, quadratic equation and list sum
- add minimal input error handling

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_683f99dee124832f880b1074e165804e